### PR TITLE
Fix issues with retaining insertion order in collections

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 versions_plugins_writtenbooks=0.5.1.1
 
 versions_dependencies_asm=9.2
-versions_dependencies_feather=1.0.0.3
+versions_dependencies_feather=1.1.0
 
 versions_dependencies_junit=4.13

--- a/src/main/java/org/parchmentmc/lodestone/asm/CodeCleaner.java
+++ b/src/main/java/org/parchmentmc/lodestone/asm/CodeCleaner.java
@@ -4,7 +4,6 @@ import org.objectweb.asm.Opcodes;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Map;
@@ -296,7 +295,7 @@ public class CodeCleaner {
                     if (mtd.getOverrides() != null) {
                         mtd.getOverrides().add(target);
                     } else {
-                        mtd.setOverrides(new HashSet<>(Collections.singletonList(target)));
+                        mtd.setOverrides(new LinkedHashSet<>(Collections.singletonList(target)));
                     }
                 }
             }

--- a/src/main/java/org/parchmentmc/lodestone/asm/CodeCleaner.java
+++ b/src/main/java/org/parchmentmc/lodestone/asm/CodeCleaner.java
@@ -51,7 +51,7 @@ public class CodeCleaner {
 
             //Resolve the 'root' owner of each method.
             for (MutableMethodInfo method : info.getMethods().values()) {
-                method.setOverrides(doFindOverrides(method, info.getName(), new TreeSet<>()));
+                method.setOverrides(findOverrides(method, info.getName()));
                 method.setParent(doFindFirstOverride(method, info.getName()));
             }
         }

--- a/src/main/java/org/parchmentmc/lodestone/asm/CodeTree.java
+++ b/src/main/java/org/parchmentmc/lodestone/asm/CodeTree.java
@@ -8,15 +8,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class CodeTree {
-    private final Set<String> noneLibraryClasses = new HashSet<>();
+    private final Set<String> noneLibraryClasses = new LinkedHashSet<>();
     private final Map<String, byte[]> sources = new HashMap<>();
 
     private final Map<String, MutableClassInfo> parsedClasses = new HashMap<>();

--- a/src/main/java/org/parchmentmc/lodestone/asm/MutableClassInfo.java
+++ b/src/main/java/org/parchmentmc/lodestone/asm/MutableClassInfo.java
@@ -7,13 +7,7 @@ import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InvokeDynamicInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 
 public class MutableClassInfo implements MutableSecuredObjectInfo {
     private static final Handle LAMBDA_METAFACTORY = new Handle(Opcodes.H_INVOKESTATIC,
@@ -46,11 +40,11 @@ public class MutableClassInfo implements MutableSecuredObjectInfo {
         this.access = node.access == 0 ? null : node.access;
         this.signature = node.signature;
 
-        this.records = new TreeMap<>();
+        this.records = new LinkedHashMap<>();
         if (node.fields == null || node.fields.isEmpty()) {
             this.fields = null;
         } else {
-            this.fields = new TreeMap<>();
+            this.fields = new LinkedHashMap<>();
             node.fields.forEach(fld -> this.fields.put(fld.name, new MutableFieldInfo(this, fld)));
         }
 
@@ -70,7 +64,7 @@ public class MutableClassInfo implements MutableSecuredObjectInfo {
                 }
             }
 
-            this.methods = new TreeMap<>();
+            this.methods = new LinkedHashMap<>();
             for (MethodNode mtd : node.methods) {
                 String key = mtd.name + mtd.desc;
                 this.methods.put(key, new MutableMethodInfo(this, mtd, lambdas.contains(this.name + '/' + key)));

--- a/src/main/java/org/parchmentmc/lodestone/asm/MutableRecordInfo.java
+++ b/src/main/java/org/parchmentmc/lodestone/asm/MutableRecordInfo.java
@@ -1,12 +1,12 @@
 package org.parchmentmc.lodestone.asm;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class MutableRecordInfo {
     private final String name;
     private final String desc;
-    private final Set<MutableMethodReferenceInfo> getters = new HashSet<>();
+    private final Set<MutableMethodReferenceInfo> getters = new LinkedHashSet<>();
 
     public MutableRecordInfo(final String name, final String desc) {
         this.name = name;

--- a/src/main/java/org/parchmentmc/lodestone/converter/ClassConverter.java
+++ b/src/main/java/org/parchmentmc/lodestone/converter/ClassConverter.java
@@ -3,9 +3,8 @@ package org.parchmentmc.lodestone.converter;
 import org.parchmentmc.feather.metadata.ClassMetadata;
 import org.parchmentmc.feather.metadata.ClassMetadataBuilder;
 import org.parchmentmc.feather.named.NamedBuilder;
+import org.parchmentmc.feather.util.CollectorUtils;
 import org.parchmentmc.lodestone.asm.MutableClassInfo;
-
-import java.util.stream.Collectors;
 
 public class ClassConverter {
 
@@ -19,12 +18,11 @@ public class ClassConverter {
                 .withSuperName(NamedBuilder.create().withObfuscated(classInfo.getSuperName()).build())
                 .withSecuritySpecifications(classInfo.getAccess())
                 .withSignature(NamedBuilder.create().withObfuscated(classInfo.getSignature()).build())
-                .withInterfaces(classInfo.getInterfaces().stream().map(interfaceName -> NamedBuilder.create().withObfuscated(interfaceName).build()).collect(Collectors.toSet()))
-                .withFields(classInfo.getFields().values().stream().map(fieldInfo -> fieldConverter.convert(classInfo, fieldInfo)).collect(Collectors.toSet()))
-                .withMethods(classInfo.getMethods().values().stream().map(methodInfo -> methodConverter.convert(classInfo, methodInfo)).collect(Collectors.toSet()))
+                .withInterfaces(classInfo.getInterfaces().stream().map(interfaceName -> NamedBuilder.create().withObfuscated(interfaceName).build()).collect(CollectorUtils.toLinkedSet()))
+                .withFields(classInfo.getFields().values().stream().map(fieldInfo -> fieldConverter.convert(classInfo, fieldInfo)).collect(CollectorUtils.toLinkedSet()))
+                .withMethods(classInfo.getMethods().values().stream().map(methodInfo -> methodConverter.convert(classInfo, methodInfo)).collect(CollectorUtils.toLinkedSet()))
                 .withRecords(
-                        classInfo.getRecords().values().stream().map(recordInfo -> recordConverter.convert(classInfo, recordInfo)).collect(
-                                Collectors.toSet())
+                        classInfo.getRecords().values().stream().map(recordInfo -> recordConverter.convert(classInfo, recordInfo)).collect(CollectorUtils.toLinkedSet())
                 )
                 .withIsRecord(classInfo.isRecord());
 

--- a/src/main/java/org/parchmentmc/lodestone/converter/MethodConverter.java
+++ b/src/main/java/org/parchmentmc/lodestone/converter/MethodConverter.java
@@ -3,11 +3,9 @@ package org.parchmentmc.lodestone.converter;
 import org.parchmentmc.feather.metadata.MethodMetadata;
 import org.parchmentmc.feather.metadata.MethodMetadataBuilder;
 import org.parchmentmc.feather.named.NamedBuilder;
+import org.parchmentmc.feather.util.CollectorUtils;
 import org.parchmentmc.lodestone.asm.MutableClassInfo;
 import org.parchmentmc.lodestone.asm.MutableMethodInfo;
-
-import java.util.LinkedHashSet;
-import java.util.stream.Collectors;
 
 public class MethodConverter {
     public MethodMetadata convert(final MutableClassInfo classInfo, final MutableMethodInfo mutableMethodInfo) {
@@ -21,7 +19,7 @@ public class MethodConverter {
                 .withSignature(NamedBuilder.create().withObfuscated(mutableMethodInfo.getSignature()).build())
                 .withSecuritySpecification(mutableMethodInfo.getAccess())
                 .withLambda(mutableMethodInfo.isLambda())
-                .withOverrides(mutableMethodInfo.getOverrides().stream().map(methodReferenceConverter::convert).collect(Collectors.toCollection(LinkedHashSet::new)))
+                .withOverrides(mutableMethodInfo.getOverrides().stream().map(methodReferenceConverter::convert).collect(CollectorUtils.toLinkedSet()))
                 .withParent(methodReferenceConverter.convert(mutableMethodInfo.getParent()))
                 .withBouncingTarget(bouncingTargetConverter.convert(mutableMethodInfo.getBouncer()))
                 .build();

--- a/src/main/java/org/parchmentmc/lodestone/tasks/MergeMetadata.java
+++ b/src/main/java/org/parchmentmc/lodestone/tasks/MergeMetadata.java
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.parchmentmc.feather.metadata.*;
 import org.parchmentmc.feather.named.Named;
 import org.parchmentmc.feather.named.NamedBuilder;
+import org.parchmentmc.feather.util.CollectorUtils;
 import org.parchmentmc.feather.utils.MetadataMerger;
 import org.parchmentmc.lodestone.util.ASMRemapper;
 
@@ -88,6 +89,7 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
             final Map<String, String> obfToMojNameMap,
             final Map<String, MethodMetadata> obfKeyToMojMethodNameMap
     ) {
+        // No need to retain insertion order, since this is only for lookup and not iterated over
         final Map<String, String> obfToMojMethodNameMap = obfKeyToMojMethodNameMap.entrySet().stream().collect(Collectors.toMap(
                 Map.Entry::getKey,
                 e -> e.getValue().getName().getMojangName().orElseThrow(() -> new IllegalStateException("Missing mojang name"))
@@ -101,7 +103,7 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
         final ClassMetadataBuilder classMetadataBuilder = ClassMetadataBuilder.create(classMetadata)
                 .withInnerClasses(classMetadata.getInnerClasses().stream()
                         .map(inner -> adaptSignatures(inner, obfToMojNameMap, obfKeyToMojMethodNameMap))
-                        .collect(Collectors.toSet()))
+                        .collect(CollectorUtils.toLinkedSet()))
                 .withMethods(classMetadata.getMethods().stream()
                         .map(method -> {
                             final MethodMetadataBuilder builder = MethodMetadataBuilder.create(method);
@@ -153,7 +155,7 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
                             }
                             return builder.build();
                         })
-                        .collect(Collectors.toSet()))
+                        .collect(CollectorUtils.toLinkedSet()))
                 .withFields(classMetadata.getFields().stream()
                         .map(field -> {
                             final FieldMetadataBuilder fieldMetadataBuilder = FieldMetadataBuilder.create(field);
@@ -187,7 +189,7 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
 
                             return fieldMetadataBuilder.build();
                         })
-                        .collect(Collectors.toSet()))
+                        .collect(CollectorUtils.toLinkedSet()))
                 .withRecords(classMetadata.getRecords().stream()
                         .map(record -> {
                             final RecordMetadataBuilder builder = RecordMetadataBuilder.create(record);
@@ -211,7 +213,7 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
 
                             return builder.build();
                         })
-                        .collect(Collectors.toSet()));
+                        .collect(CollectorUtils.toLinkedSet()));
 
 
         if (!classMetadata.getSuperName().hasMojangName() && classMetadata.getSuperName().hasObfuscatedName()) {
@@ -262,6 +264,7 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
             final Map<String, MethodMetadata> obfKeyToMojMethodNameMap,
             final Map<String, FieldMetadata> obfKeyToMojFieldNameMap
     ) {
+        // No need to retain insertion order, since this is only for lookup and not iterated over
         final Map<String, String> obfToMojMethodNameMap = obfKeyToMojMethodNameMap.entrySet().stream().collect(Collectors.toMap(
                 Map.Entry::getKey,
                 e -> e.getValue()
@@ -278,7 +281,7 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
         final ClassMetadataBuilder classMetadataBuilder = ClassMetadataBuilder.create(classMetadata)
                 .withInnerClasses(classMetadata.getInnerClasses().stream()
                         .map(inner -> adaptReferences(inner, obfToMojNameMap, obfKeyToMojMethodNameMap, obfKeyToMojFieldNameMap))
-                        .collect(Collectors.toSet()))
+                        .collect(CollectorUtils.toLinkedSet()))
                 .withMethods(classMetadata.getMethods().stream()
                         .map(method -> {
                             final MethodMetadataBuilder builder = MethodMetadataBuilder.create(method);
@@ -350,7 +353,7 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
 
                             return builder.build();
                         })
-                        .collect(Collectors.toSet()))
+                        .collect(CollectorUtils.toLinkedSet()))
                 .withRecords(classMetadata.getRecords().stream()
                         .map(record -> {
                             final RecordMetadataBuilder builder = RecordMetadataBuilder.create(record);
@@ -376,7 +379,7 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
 
                             return builder.build();
                         })
-                        .collect(Collectors.toSet()));
+                        .collect(CollectorUtils.toLinkedSet()));
         return classMetadataBuilder.build();
     }
 

--- a/src/main/java/org/parchmentmc/lodestone/tasks/MergeMetadata.java
+++ b/src/main/java/org/parchmentmc/lodestone/tasks/MergeMetadata.java
@@ -16,7 +16,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -31,9 +31,9 @@ public abstract class MergeMetadata extends MinecraftVersionTask {
     public abstract RegularFileProperty getOutput();
 
     private static SourceMetadata adaptTypes(final SourceMetadata sourceMetadata) {
-        final Map<String, String> obfToMojClassNameMap = new HashMap<>();
-        final Map<String, MethodMetadata> obfKeyToMojMethodNameMap = new HashMap<>();
-        final Map<String, FieldMetadata> obfKeyToMojFieldNameMap = new HashMap<>();
+        final Map<String, String> obfToMojClassNameMap = new LinkedHashMap<>();
+        final Map<String, MethodMetadata> obfKeyToMojMethodNameMap = new LinkedHashMap<>();
+        final Map<String, FieldMetadata> obfKeyToMojFieldNameMap = new LinkedHashMap<>();
         sourceMetadata.getClasses().forEach(classMetadata -> {
             collectClassNames(classMetadata, obfToMojClassNameMap);
             collectMethodNames(classMetadata, obfKeyToMojMethodNameMap);


### PR DESCRIPTION
This PR fixes numerous places in the codebase where insertion order is not retained in collections, whether because a general-purpose collector is used (which may not retain insertion order) or because a sorted collection is used (like `TreeSet`s).

This also includes an update to Feather, which includes similar bugfixes with regards to collections not retaining insertion order of their elements.

This PR depends on #3.